### PR TITLE
Make all images medium-zoom images so we can use markdown image syntax

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,5 +11,5 @@ Fund Data Centers as well as more general bioinformatics training.
 
 To get started, choose a Lesson Topic from the navigation bar.
 
-<div><img class="zoom-default" src="https://i.imgur.com/5pv1CQL.png" alt="drawing" width="300" align="top"/></div>
+![This is an image](https://i.imgur.com/5pv1CQL.png)
 

--- a/docs/javascript/extra.js
+++ b/docs/javascript/extra.js
@@ -1,2 +1,6 @@
 // Turn any image with class attribute of "zoom-default" to a medium-zoom image
+img = document.getElementsByTagName('img');
+for(i = 0; i < img.length; i++) {
+    img[i].className += " zoom-default";
+}
 const zoomDefault = mediumZoom('.zoom-default')


### PR DESCRIPTION
This modifies some Javascript included on all pages so that every image will have the `zoom-default` class applied to it. This allows every image on the site to become a medium-zoom image.